### PR TITLE
CI(QoS4B): cache path fix

### DIFF
--- a/.github/workflows/build-bundleme-gui-qos4b.yml
+++ b/.github/workflows/build-bundleme-gui-qos4b.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           node-version: "20.19.4"
           cache: "npm"
-          cache-dependency-path: tools/bundleme-gui/package-lock.json
+          cache-dependency-path: '**/package-lock.json'
       - name: Ensure lockfile
         working-directory: tools/bundleme-gui
         run: |


### PR DESCRIPTION
Broaden cache-dependency-path to '**/package-lock.json' so setup-node cache resolves on first run. Retry QoS4B after merge.